### PR TITLE
feat: bump to 2.20

### DIFF
--- a/addons/sourcemod/scripting/FixSprayExploit.sp
+++ b/addons/sourcemod/scripting/FixSprayExploit.sp
@@ -1,6 +1,6 @@
 /*
 *	Spray Exploit Fixer
-*	Copyright (C) 2022 Silvers
+*	Copyright (C) 2023 Silvers
 *
 *	This program is free software: you can redistribute it and/or modify
 *	it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 
 
 
-#define PLUGIN_VERSION 		"2.18"
+#define PLUGIN_VERSION 		"2.20"
 
 /*=======================================================================================
 	Plugin Info:
@@ -32,8 +32,18 @@
 ========================================================================================
 	Change Log:
 
+2.20 (20-Jan-2023)
+	- Now logs if a Steam ID is unverified.
+	- Now prevents log spamming duplicate entries.
+	- Fixed checking bots for sprays.
+	- Thanks to ".Rushaway" for reporting and help testing.
+
+2.19 (07-Jan-2023)
+	- Fixed processing getting stuck. Thanks to "SuperConker" for reporting and help testing.
+	- Fixed invalid handle errors. Thanks to "nikooo777" for reporting.
+
 2.18 (24-Dec-2022)
-	- Fixed moving sprays causing a script execution timed out error. Thanks to ".Rushaway" for reporting.
+	- Changed moving sprays to use an asynchronous method to prevent a script execution timed out error. Thanks to ".Rushaway" for reporting.
 
 2.17 (08-Oct-2022)
 	- Fixed command "sm_spray_test" getting stuck processing under certain conditions.
@@ -166,9 +176,11 @@ char g_sPath2[MAXPLAYERS+1][PLATFORM_MAX_PATH];
 ConVar g_hCvarBan, g_hCvarKick, g_hCvarLog, g_hCvarMsg, g_hCvarPath;
 EngineVersion g_iEngine;
 StringMap g_smChecked;
-ArrayList g_alFiles;
+StringMap g_smReceive;
+StringMap g_smWaiting;
 int g_iTotal;
 float g_fTime;
+bool g_bLate;
 bool g_bProc;
 bool g_bDecal;
 bool g_bSourceBans;
@@ -202,6 +214,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	MarkNativeAsOptional("MABanPlayer");
 
 	g_iEngine = GetEngineVersion();
+	g_bLate = late;
 
 	return APLRes_Success;
 }
@@ -251,6 +264,8 @@ public void OnPluginStart()
 	g_hCvarPath.AddChangeHook(ConVarChanged_Cvars);
 
 	g_smChecked = new StringMap();
+	g_smReceive = new StringMap();
+	g_smWaiting = new StringMap();
 
 	AddTempEntHook("Player Decal", PlayerDecal);
 
@@ -260,7 +275,8 @@ public void OnPluginStart()
 	StrCat(sPath, sizeof(sPath), PATH_BACKUP);
 	CreateDirectory(sPath, 511, true);
 
-	MoveSprays();
+	if( !g_bLate )
+		MoveSprays();
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3])
@@ -296,6 +312,19 @@ public void OnClientDisconnect(int client)
 {
 	if( IsFakeClient(client) ) return;
 
+	if( IsClientConnected(client) )
+	{
+		static char auth[32];
+		GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
+		g_smWaiting.Remove(auth);
+	}
+
+	g_smChecked.Remove(g_sPath1[client]);
+	g_smReceive.Remove(g_sPath1[client]);
+	g_smChecked.Remove(g_sPath2[client]);
+	g_smReceive.Remove(g_sPath2[client]);
+
+	/*
 	static char sPath[PLATFORM_MAX_PATH];
 	static char sOld[PLATFORM_MAX_PATH];
 	static char sNew[PLATFORM_MAX_PATH];
@@ -325,9 +354,15 @@ public void OnClientDisconnect(int client)
 		if( sPath[0] )
 		{
 			if( i == 0 )
+			{
 				g_smChecked.Remove(g_sPath1[client]);
+				g_smReceive.Remove(g_sPath1[client]);
+			}
 			else
+			{
 				g_smChecked.Remove(g_sPath2[client]);
+				g_smReceive.Remove(g_sPath2[client]);
+			}
 
 			Format(sOld, sizeof(sOld), "%s%s.dat", g_sDownloads, sPath);
 			Format(sNew, sizeof(sNew), "%s%s/%s.dat", g_sDownloads, PATH_BACKUP, sPath);
@@ -348,11 +383,14 @@ public void OnClientDisconnect(int client)
 			}
 		}
 	}
+	*/
 }
 
 public void OnMapEnd()
 {
 	MoveSprays();
+	g_smReceive.Clear();
+	g_smWaiting.Clear();
 }
 
 void ConVarChanged_Cvars(Handle convar, const char[] oldValue, const char[] newValue)
@@ -374,20 +412,18 @@ Action CmdSprays(int client, int args)
 	g_bProc = true;
 	g_fTime = GetEngineTime();
 
-	delete g_alFiles;
-	g_alFiles = new ArrayList(ByteCountToCells(PLATFORM_MAX_PATH));
+	ArrayList aList = new ArrayList(ByteCountToCells(PLATFORM_MAX_PATH));
 
 	int pos = StrContains(g_sDownloads, "/");
 	if( pos != -1 ) g_sDownloads[pos] = 0;
 
-	RecursiveFiles(g_alFiles, false, g_sDownloads);
+	RecursiveFiles(aList, false, g_sDownloads);
 
 	if( pos != -1 ) g_sDownloads[pos] = '/';
 
 	int count, counts;
-	RecursiveSearchDirs(client, g_alFiles, count, counts, false);
+	RecursiveSearchDirs(client, aList, count, counts, false);
 
-	delete g_alFiles;
 	return Plugin_Handled;
 }
 
@@ -486,16 +522,15 @@ void MoveSprays()
 {
 	int count, counts;
 
-	delete g_alFiles;
-	g_alFiles = new ArrayList(ByteCountToCells(PLATFORM_MAX_PATH));
+	ArrayList aList = new ArrayList(ByteCountToCells(PLATFORM_MAX_PATH));
 
 	strcopy(g_sMoveFiles, sizeof(g_sMoveFiles), g_sDownloads);
 
 	int pos = StrContains(g_sMoveFiles, "/");
 	if( pos != -1 ) g_sMoveFiles[pos] = 0;
 
-	RecursiveFiles(g_alFiles, true, g_sMoveFiles);
-	RecursiveSearchDirs(0, g_alFiles, count, counts, true);
+	RecursiveFiles(aList, true, g_sMoveFiles);
+	RecursiveSearchDirs(0, aList, count, counts, true);
 }
 
 void RecursiveSearchDirs(int client, ArrayList aList, int &count, int &counts, bool move = false)
@@ -571,12 +606,14 @@ void RecursiveSearchDirs(int client, ArrayList aList, int &count, int &counts, b
 			g_bProc = false;
 
 			ReplyToCommand(client, "[Sprays] downloads checked. Found %d of %d invalid. Took %0.2f seconds.", count, counts, GetEngineTime() - g_fTime);
+
+			delete aList;
 		}
 		else
 		{
 			DeleteEmptyDirs(g_sMoveFiles);
 
-			delete g_alFiles;
+			delete aList;
 		}
 	}
 }
@@ -653,6 +690,12 @@ Action PlayerDecal(const char[] te_name, const int[] Players, int numClients, fl
 		return Plugin_Handled;
 	}
 
+	if( IsFakeClient(client) )
+	{
+		return Plugin_Continue;
+	}
+
+	g_sFilename[0] = 0;
 	GetPlayerDecalFile(client, g_sFilename, sizeof(g_sFilename));
 
 	bool val;
@@ -676,8 +719,13 @@ Action PlayerDecal(const char[] te_name, const int[] Players, int numClients, fl
 
 	if( !val )
 	{
-		char auth[20];
+		static char auth[32];
 		GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
+		if( strncmp(auth[6], "ID_", 3) == 0 )
+		{
+			GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
+			Format(auth, sizeof(auth), "Unverified: %s", auth);
+		}
 
 		if( FileExists(g_sFilename) )
 		{
@@ -688,8 +736,12 @@ Action PlayerDecal(const char[] te_name, const int[] Players, int numClients, fl
 		}
 		else
 		{
-			if( g_hCvarLog.IntValue ) LogCustom("Blocked unchecked spray - missing file: %s from (%N) [%s]", g_sFilename, client, auth);
-			if( g_hCvarMsg.IntValue == 1 ) PrintToServer("[Spray Exploit] Blocked unchecked spray - missing file: %s from (%N) [%s]", g_sFilename, client, auth);
+			if( !g_smWaiting.GetValue(auth, val) )
+			{
+				g_smWaiting.SetValue(auth, true);
+				if( g_hCvarLog.IntValue ) LogCustom("Blocked unchecked spray - missing file: %s from (%N) [%s]", g_sFilename, client, auth);
+				if( g_hCvarMsg.IntValue == 1 ) PrintToServer("[Spray Exploit] Blocked unchecked spray - missing file: %s from (%N) [%s]", g_sFilename, client, auth);
+			}
 		}
 
 		float vPos[3];
@@ -801,27 +853,56 @@ public Action OnFileReceive(int client, const char[] sFile)
 	client = GetClientFromSpray();
 	if( !client ) client = GetClientFromJingle();
 
-	if( g_hCvarLog.IntValue == 1 )
+	bool log;
+
+	if( client )
+	{
+		static char sPath[PLATFORM_MAX_PATH];
+
+		GetPlayerDecalFile(client, sPath, sizeof(sPath));
+		if( strcmp(sPath, g_sPath1[client]) )
+		{
+			ReplaceString(sPath, sizeof(sPath), g_sDownloads, "");
+			strcopy(g_sPath1[client], sizeof(g_sPath1[]), sPath);
+			log = true;
+		}
+
+		GetPlayerJingleFile(client, sPath, sizeof(sPath));
+		if( strcmp(sPath, g_sPath2[client]) )
+		{
+			ReplaceString(sPath, sizeof(sPath), g_sDownloads, "");
+			strcopy(g_sPath2[client], sizeof(g_sPath2[]), sPath);
+			log = true;
+		}
+	}
+	else
+	{
+		log = true;
+	}
+
+	if( log && g_hCvarLog.IntValue == 1 )
 	{
 		if( client )
 		{
-			static char auth[20];
+			static char auth[32];
 			GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
+			if( strncmp(auth[6], "ID_", 3) == 0 )
+			{
+				GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
+				Format(auth, sizeof(auth), "Unverified: %s", auth);
+			}
+
 			LogCustom("File received: %s from (%N) [%s]", sFile, client, auth);
 		}
 		else
 		{
-			LogCustom("File received: %s", sFile);
+			int val;
+			if( !g_smReceive.GetValue(sFile, val) )
+			{
+				g_smReceive.SetValue(sFile, true);
+				LogCustom("File received: %s", sFile);
+			}
 		}
-	}
-
-	if( client )
-	{
-		GetPlayerDecalFile(client, g_sPath1[client], sizeof(g_sPath1[]));
-		ReplaceString(g_sPath1[client], sizeof(g_sPath1[]), g_sDownloads, "");
-
-		GetPlayerJingleFile(client, g_sPath2[client], sizeof(g_sPath2[]));
-		ReplaceString(g_sPath2[client], sizeof(g_sPath2[]), g_sDownloads, "");
 	}
 
 	return Plugin_Continue;
@@ -869,8 +950,14 @@ void FileCheck()
 					if( !client ) client = GetClientFromJingle();
 					if( client )
 					{
-						char auth[20];
+						char auth[32];
 						GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
+						if( strncmp(auth[6], "ID_", 3) == 0 )
+						{
+							GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
+							Format(auth, sizeof(auth), "Unverified: %s", auth);
+						}
+
 						if( g_hCvarLog.IntValue ) LogCustom("Invalid spray: %s from (%N) [%s]", g_sFilename, client, auth);
 						if( g_hCvarMsg.IntValue ) PrintToServer("[Spray Exploit] Invalid spray: %s: %02d (%02X <> %02X) from (%N) [%s]", g_sFilename, i, iRead[i], g_iVal[i], client, auth);
 					} else {


### PR DESCRIPTION
2.20 (20-Jan-2023)
	- Now logs if a Steam ID is unverified.
	- (Major improvement!!) Now prevents log spamming duplicate entries.
	- Fixed checking bots for sprays.
	- Thanks to ".Rushaway" for reporting and help testing.
	
2.19 (07-Jan-2023)
	- Fixed processing getting stuck. Thanks to "SuperConker" for reporting and help testing.
	- Fixed invalid handle errors. Thanks to "nikooo777" for reporting.